### PR TITLE
Support for FAS icons + Numerous QOL Changes

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -1,5 +1,4 @@
 baseURL = "https://demo.uicard.io/hugo-uilite-free/"
 languageCode = "en-us"
 title = "Valentina"
-theme = "uilite"
-
+theme = "hugo-uilite"

--- a/exampleSite/data/sidebar.json
+++ b/exampleSite/data/sidebar.json
@@ -1,6 +1,6 @@
 {
 	"title" : "hey world, i'm",
 	"highlightedText" : "valentina",
-	"description" : "A graphics designer, based in Germany",
+	"description" : "A graphics designer, based in Germany.",
 	"displayPicture" : "sim.jpg"
 }

--- a/exampleSite/data/socialfas.json
+++ b/exampleSite/data/socialfas.json
@@ -1,0 +1,3 @@
+{
+  "envelope" : "mailto:<youremail>@gmail.com"
+}

--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -1,4 +1,5 @@
 {{ $config := .Site.Data.config }}
+
 <section id="contact" class="bg-light d-flex align-items-center" style="height: 100vh;">
   <div class="container">
       <h2 class="heading mb-3">Contact</h2>
@@ -18,7 +19,7 @@
             <input type="email" class="form-control" name="_replyto" placeholder="Email">
           </div>
         </div>
-    
+
         <div class="form-group">
           <label>Message</label>
           <textarea placeholder="Message" name="message" class="form-control" rows="4"></textarea>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -1,5 +1,7 @@
 {{ $sidebar := .Site.Data.sidebar }}
 {{ $social := .Site.Data.social }}
+{{ $socialfas := .Site.Data.socialfas}}
+
 <section id="sidebar" class="sidebar d-flex align-items-center p-5">
   <div class="main-info">
 
@@ -15,11 +17,17 @@
           <i class="fab fa-{{ $key }}"></i>
         </a>
       {{ end }}
-      
+
+      {{ range $key, $value := $socialfas }}
+        <a target="_blank" href="{{ $value }}">
+          <i class="fas fa-{{ $key }}"></i>
+        </a>
+      {{ end }}
+
     </div>
-    
+
     <a href="#contact" class="btn btn-dark btn-lg">Contact</a>
 
-    
+
   </div>
 </section>


### PR DESCRIPTION
Thanks for the theme. These are some changes I made on my personal website that I believe would also be useful in the repo.

List of changes in this Pull Request:

* exampleSite/config.toml - changed default theme directory to hugo-uilite opposed to uilite.
  * This repo's name is hugo-uilite, so the user would have to rename the folder in /themes or change the config.toml to "hugo-uilite" from "uilite" when running an example site. This fixes that problem.

* Added support for awesome fas icons (opposed to only fab). This is useful if a user wants to have a mail icon for example. **By default this creates a new envelope icon in the exampleSite sidebar.** This can be removed in exampleSite/data/socialfas.json.
  * New fas icons should be placed in exampleSite/data/socialfas.json.
  * Fas icons are rendered after the fab icons.

* Added period after description in exampleSite/data/sidebar.json
* Added a newline after variable declaration in layouts/partials/contact.html and layouts/partial /sidebar.html to match with other html files.