### PR TITLE
Adds rel-me to social links

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -11,7 +11,7 @@
     <div class="social my-4">
 
       {{ range $key, $value := $social }}
-        <a target="_blank" href="{{ $value }}">
+        <a target="_blank" href="{{ $value }}" rel="me">
           <i class="fab fa-{{ $key }}"></i>
         </a>
       {{ end }}


### PR DESCRIPTION
[rel="me"](https://indieweb.org/rel-me) is a commonly used way to show that that two websites or social media accounts are the same, and is used for authentication and proving site ownership in a variety of ways.