### PR TITLE
Fix behance URL in social.json

### DIFF
--- a/exampleSite/data/social.json
+++ b/exampleSite/data/social.json
@@ -2,5 +2,5 @@
 	"facebook" : "https://facebook.com/<yourusername>",
 	"instagram" : "https://instagram.com/<yourusername>",
 	"dribbble" : "https://dribbble.com/<yourusername>",
-	"behance" : "https://behnace.com/<yourusername>"
+	"behance" : "https://behance.com/<yourusername>"
 }


### PR DESCRIPTION
This is a small modification to `data/social.json` for `exampleSite` that uses behance.com instead of behnace.com.

Thanks!

--
Brie