### PR TITLE
Fixing formspree integration and adding steps to readme.md and exampleSite

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,9 @@ Hugo UILite portfolio theme is designed especially for designers and developers 
 ### Useful Links
 
 [Free Demo](https://demo.uicard.io/hugo-uilite-free/) | [Pro Demo](https://demo.uicard.io/hugo-uilite-portfolio-demo/) | [More Info](https://uicard.io/products/hugo-uilite-pro?utm_source=github)
+
+### Contact via Formspree
+
+- [Register](https://formspree.io/)
+- [Create a Project and a Form](https://help.formspree.io/hc/en-us/articles/360053239754-Getting-started-with-projects)
+- Add your **form endpoint** to `data/config.json

--- a/README.md
+++ b/README.md
@@ -29,4 +29,4 @@ Hugo UILite portfolio theme is designed especially for designers and developers 
 
 - [Register](https://formspree.io/)
 - [Create a Project and a Form](https://help.formspree.io/hc/en-us/articles/360053239754-Getting-started-with-projects)
-- Add your **form endpoint** to `data/config.json
+- Add your **form endpoint** to `data/config.json`

--- a/exampleSite/data/config.json
+++ b/exampleSite/data/config.json
@@ -1,4 +1,5 @@
 {
 	"author" : "Arvind Singh",
-	"email" : "youremailhere@gmail.com"
+	"email" : "youremailhere@gmail.com",
+	"formspree" : "https://your-form-endpoint-goes-here"
 }

--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -8,7 +8,7 @@
         {{ $config.message }}
       </div>
 
-      <form action="https://formspree.io/{{ $config.email }}" method="post">
+      <form action="{{ $config.formspree }}" method="post">
         <div class="form-row">
           <div class="col-12 col-xl-6 col-lg-6 col-md-6">
             <label>Name</label>


### PR DESCRIPTION
Simple change, adding the formspree e-mail straight to the url won't work (I have tested that). So you have to generate a Project + Form at formspree.io and add the form endpoint to the html form action. 